### PR TITLE
Delete security groups after servers and ports.

### DIFF
--- a/ospurge/resources/neutron.py
+++ b/ospurge/resources/neutron.py
@@ -137,6 +137,12 @@ class Networks(base.ServiceResource):
 class SecurityGroups(base.ServiceResource):
     ORDER = 49
 
+    def check_prerequisite(self):
+        # We do not want to reimplement `Ports.list` here in respect to the DRY
+        # principle.
+        return (self.list_other_resource('Servers') == [] and
+                self.list_other_resource('Ports') == [])
+
     def list(self):
         return [sg for sg in self.cloud.list_security_groups(
             filters={'tenant_id': self.cleanup_project_id})

--- a/ospurge/tests/resources/test_base.py
+++ b/ospurge/tests/resources/test_base.py
@@ -167,6 +167,7 @@ class TestServiceResource(unittest.TestCase):
         creds_manager = mock.Mock()
         resource_manager = base.ServiceResource(creds_manager)
 
+        self.assertEqual(resource_manager.creds_manager, creds_manager)
         self.assertEqual(resource_manager.cloud, creds_manager.cloud)
         self.assertEqual(resource_manager.options, creds_manager.options)
         self.assertEqual(resource_manager.cleanup_project_id,
@@ -238,3 +239,36 @@ class TestServiceResource(unittest.TestCase):
                 mock.Mock(is_set=mock.Mock(return_value=False)))
 
         self.assertEqual(3, m.call_count)
+
+    def test_list_other_resource(self):
+        class Foo1(base.ServiceResource):
+            ORDER = 1
+
+            def list(self):
+                return ['foo_1']
+
+            def delete(self, resource):
+                return True
+
+            @staticmethod
+            def to_str(resource):
+                return "Foo 1"
+
+        class Foo2(base.ServiceResource):
+            ORDER = 2
+
+            def list(self):
+                return ['foo_2']
+
+            def delete(self, resource):
+                return True
+
+            @staticmethod
+            def to_str(resource):
+                return "Foo 2"
+
+        creds_manager = mock.Mock()
+        foo1 = Foo1(creds_manager)
+        foo2 = Foo2(creds_manager)
+        self.assertEqual(foo1.list_other_resource('Foo2'), ['foo_2'])
+        self.assertEqual(foo2.list_other_resource('Foo1'), ['foo_1'])

--- a/ospurge/tests/resources/test_neutron.py
+++ b/ospurge/tests/resources/test_neutron.py
@@ -234,3 +234,18 @@ class TestSecurityGroups(unittest.TestCase):
         sg = mock.MagicMock()
         self.assertIn("Security Group (",
                       neutron.SecurityGroups(self.creds_manager).to_str(sg))
+
+    def test_check_prerequisite(self):
+        self.cloud.list_ports.return_value = [
+            {'device_owner': 'network:dhcp'},
+            {'device_owner': 'network:router_interface'},
+            {'device_owner': 'network:router_interface_distributed'},
+            {'device_owner': ''}
+        ]
+        security_groups = neutron.SecurityGroups(self.creds_manager)
+        ports = security_groups.list_other_resource('Ports')
+        self.assertEqual([{'device_owner': ''}], ports)
+        security_groups.check_prerequisite()
+        self.cloud.list_ports.assert_called_once_with(
+            filters={'tenant_id': self.creds_manager.project_id})
+        self.cloud.list_servers.assert_called_once_with()


### PR DESCRIPTION
Even though SecurityGroups.ORDER comes after servers and ports, server
and ports deletion can take a long time.
We need to check them in SecurityGroups.check_prerequisite.
Also, we need to call `Ports.list` in order to stay DRY and to not repeat
ourselves, so we add a ServiceResource.list_other_resource which is
handy when resources depend on others in `check_prerequisite`.

Change-Id: Icf970770ec31b086a7d1d76739c93c97b1324229
Closes-Bug: #1831641

By Yves-Gwenael Bourhis <yves-gwenael.bourhis@orange.com>
See https://review.opendev.org/#/c/663068/