### PR TITLE
Fix exception handling if delete fails

### DIFF
--- a/ospurge/main.py
+++ b/ospurge/main.py
@@ -199,7 +199,11 @@ def runner(resource_mngr, options, exit):
                 # mypy complains: "Exception" has no attribute
                 # "inner_exception"
                 exc_info = exc.inner_exception  # type: ignore
-                if exc_info[0].__name__.lower().endswith('endpointnotfound'):
+                exc_type = exc_info[0]
+                if (
+                    exc_type is not None and
+                    exc_type.__name__.lower().endswith('endpointnotfound')
+                ):
                     return True
             return False
 


### PR DESCRIPTION
Fixes an issue where ospurge silently stopped deleting resources if
deleting one resource failed.

If there is an exception while deleting some resource and that exception
does not have an inner exception the exception handling raised another
exception and the error was not propagated to the ospurge return code.
No error appeared in the log either.