### PR TITLE
Rename neutron filter tenant_id to project_id

### DIFF
--- a/ospurge/resources/neutron.py
+++ b/ospurge/resources/neutron.py
@@ -21,7 +21,7 @@ class FloatingIPs(base.ServiceResource):
 
     def list(self):
         return self.cloud.search_floating_ips(filters={
-            'tenant_id': self.cleanup_project_id
+            'project_id': self.cleanup_project_id
         })
 
     def delete(self, resource):
@@ -45,7 +45,7 @@ class RouterInterfaces(base.ServiceResource):
         return (
             self.cloud.list_servers() == [] and
             self.cloud.search_floating_ips(
-                filters={'tenant_id': self.cleanup_project_id}
+                filters={'project_id': self.cleanup_project_id}
             ) == []
         )
 
@@ -55,7 +55,7 @@ class RouterInterfaces(base.ServiceResource):
                 'device_owner': ['network:router_interface',
                                  'network:router_interface_distributed',
                                  'network:ha_router_replicated_interface'],
-                'tenant_id': self.cleanup_project_id}
+                'project_id': self.cleanup_project_id}
         )
 
     def delete(self, resource):
@@ -77,7 +77,7 @@ class Routers(base.ServiceResource):
                 'device_owner': ['network:router_interface',
                                  'network:router_interface_distributed',
                                  'network:ha_router_replicated_interface'],
-                'tenant_id': self.cleanup_project_id}
+                'project_id': self.cleanup_project_id}
         ) == []
 
     def list(self):
@@ -103,7 +103,7 @@ class Ports(base.ServiceResource):
 
     def list(self):
         ports = self.cloud.list_ports(
-            filters={'tenant_id': self.cleanup_project_id}
+            filters={'project_id': self.cleanup_project_id}
         )
         excluded = ['network:dhcp',
                     'network:router_interface',
@@ -128,7 +128,7 @@ class Networks(base.ServiceResource):
 
     def check_prerequisite(self):
         ports = self.cloud.list_ports(
-            filters={'tenant_id': self.cleanup_project_id}
+            filters={'project_id': self.cleanup_project_id}
         )
         excluded = ['network:dhcp']
         return [p for p in ports if p['device_owner'] not in excluded] == []
@@ -136,7 +136,7 @@ class Networks(base.ServiceResource):
     def list(self):
         networks = []
         for network in self.cloud.list_networks(
-                filters={'tenant_id': self.cleanup_project_id}
+                filters={'project_id': self.cleanup_project_id}
         ):
             if network['router:external'] is True:
                 if not self.options.delete_shared_resources:
@@ -168,7 +168,7 @@ class SecurityGroups(base.ServiceResource):
 
     def list(self):
         return [sg for sg in self.cloud.list_security_groups(
-            filters={'tenant_id': self.cleanup_project_id})
+            filters={'project_id': self.cleanup_project_id})
             if sg['name'] != 'default']
 
     def delete(self, resource):

--- a/ospurge/tests/resources/test_neutron.py
+++ b/ospurge/tests/resources/test_neutron.py
@@ -38,7 +38,7 @@ class TestFloatingIPs(unittest.TestCase):
         self.assertIs(self.cloud.search_floating_ips.return_value,
                       neutron.FloatingIPs(self.creds_manager).list())
         self.cloud.search_floating_ips.assert_called_once_with(
-            filters={'tenant_id': self.creds_manager.project_id}
+            filters={'project_id': self.creds_manager.project_id}
         )
 
     def test_delete(self):
@@ -80,7 +80,7 @@ class TestRouterInterfaces(unittest.TestCase):
         self.assertEqual(False, ifaces_manager.check_prerequisite())
 
         self.cloud.search_floating_ips.assert_called_with(
-            filters={'tenant_id': self.creds_manager.project_id}
+            filters={'project_id': self.creds_manager.project_id}
         )
 
     def test_list(self):
@@ -91,7 +91,7 @@ class TestRouterInterfaces(unittest.TestCase):
                 'device_owner': ['network:router_interface',
                                  'network:router_interface_distributed',
                                  'network:ha_router_replicated_interface'],
-                'tenant_id': self.creds_manager.project_id}
+                'project_id': self.creds_manager.project_id}
         )
 
     def test_delete(self):
@@ -137,7 +137,7 @@ class TestRouters(unittest.TestCase):
                 'device_owner': ['network:router_interface',
                                  'network:router_interface_distributed',
                                  'network:ha_router_replicated_interface'],
-                'tenant_id': self.creds_manager.project_id}
+                'project_id': self.creds_manager.project_id}
         )
 
     def test_list(self):
@@ -179,7 +179,7 @@ class TestPorts(unittest.TestCase):
         ports = neutron.Ports(self.creds_manager).list()
         self.assertEqual([{'device_owner': ''}], ports)
         self.cloud.list_ports.assert_called_once_with(
-            filters={'tenant_id': self.creds_manager.project_id})
+            filters={'project_id': self.creds_manager.project_id})
 
     def test_delete(self):
         port = mock.MagicMock()
@@ -215,7 +215,7 @@ class TestNetworks(unittest.TestCase):
             False, neutron.Networks(self.creds_manager).check_prerequisite())
 
         self.cloud.list_ports.assert_called_with(
-            filters={'tenant_id': self.creds_manager.project_id}
+            filters={'project_id': self.creds_manager.project_id}
         )
 
     def test_list(self):
@@ -230,7 +230,7 @@ class TestNetworks(unittest.TestCase):
         self.assertEqual(2, len(nw_list))
 
         self.cloud.list_networks.assert_called_with(
-            filters={'tenant_id': self.creds_manager.project_id}
+            filters={'project_id': self.creds_manager.project_id}
         )
 
     def test_delete(self):
@@ -264,7 +264,7 @@ class TestSecurityGroups(unittest.TestCase):
         self.assertEqual(
             1, len(neutron.SecurityGroups(self.creds_manager).list()))
         self.cloud.list_security_groups.assert_called_once_with(
-            filters={'tenant_id': self.creds_manager.project_id}
+            filters={'project_id': self.creds_manager.project_id}
         )
 
     def test_delete(self):
@@ -295,5 +295,5 @@ class TestSecurityGroups(unittest.TestCase):
         self.assertEqual([{'device_owner': ''}], ports)
         security_groups.check_prerequisite()
         self.cloud.list_ports.assert_called_once_with(
-            filters={'tenant_id': self.creds_manager.project_id})
+            filters={'project_id': self.creds_manager.project_id})
         self.cloud.list_servers.assert_called_once_with()


### PR DESCRIPTION
Recent openstacksdk versions don't support the tenant_id filter key
for some neutron resource types anymore.
Should use project_id everywhere for neutron.